### PR TITLE
fix:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM alpine:3.13.1
 
 RUN apk add --no-cache python2 \
     && python2 -m ensurepip \
-    && python2 -m pip install cqlsh
+    && python2 -m pip install cqlsh \
+    && apk upgrade zlib expat
 
 COPY --from=build-server-env /workspace/service/service /
 COPY --from=build-server-env /workspace/service/config.yaml /


### PR DESCRIPTION
CVE-2022-40674 for expat/2.2.10-r1 (alpine)
CVE-2021-45960 for expat/2.2.10-r1 (alpine)
CVE-2022-37434 for zlib/1.2.11-r3 (alpine)